### PR TITLE
Fix CSV rename comment in notebook

### DIFF
--- a/notebooks/01_data_ingestion.ipynb
+++ b/notebooks/01_data_ingestion.ipynb
@@ -95,7 +95,7 @@
     "# List unpacked CSV files\n",
     "csv_files = list(Path(RAW_DATA_DIR).glob('*.csv'))\n",
     "\n",
-    "# Rename the first CSV found based on the date\n",
+    "# Rename the first CSV to a standard filename.\n",
     "if csv_files:\n",
     "    old_path = csv_files[0]\n",
     "    new_filename = f'kaggle_cancer_patients_raw.csv'\n",


### PR DESCRIPTION
## Summary
- clarify rename logic comment in data ingestion notebook

## Testing
- `pytest -q` *(fails: command not found)*