### PR TITLE
Add random_state to model training notebook

### DIFF
--- a/notebooks/04_model_training.ipynb
+++ b/notebooks/04_model_training.ipynb
@@ -317,7 +317,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.3)"
+    "x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.3, random_state=42)"
    ]
   },
   {
@@ -357,7 +357,7 @@
     }
    ],
    "source": [
-    "model = RandomForestRegressor(max_depth=5).fit(x_train, y_train.ravel())\n",
+    "model = RandomForestRegressor(max_depth=5, random_state=42).fit(x_train, y_train.ravel())\n",
     "\n",
     "joblib.dump(model, '../models/treatment_cost_model.pkl')"
    ]


### PR DESCRIPTION
## Summary
- ensure reproducible data splitting and modeling
- set `random_state=42` for `train_test_split` and `RandomForestRegressor`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6845ce8672ec832babfb6a03c86a14e9