### PR TITLE
Fix script for model predictions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 kaggle
 pandas
-sklearn
+numpy
+scikit-learn
 joblib


### PR DESCRIPTION
## Summary
- refactor prediction script with preprocessing step and comments
- include numpy and scikit-learn in requirements

## Testing
- `python test.py` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_b_684eff2941c8832b8e0c43006ed6279d